### PR TITLE
Add base delegates in purpose of removing boilerplate

### DIFF
--- a/app/src/main/java/com/example/hrautomation/data/repository/ProductRepository.kt
+++ b/app/src/main/java/com/example/hrautomation/data/repository/ProductRepository.kt
@@ -4,7 +4,7 @@ import com.example.hrautomation.data.model.ProductResponse
 import com.example.hrautomation.data.model.ProductResponseToProductMapper
 import com.example.hrautomation.domain.model.ProductToListedProductItemMapper
 import com.example.hrautomation.domain.repository.IProductRepository
-import com.example.hrautomation.presentation.model.ProductItem
+import com.example.hrautomation.presentation.base.delegates.BaseListItem
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -16,7 +16,8 @@ class ProductRepository @Inject constructor() : IProductRepository {
         ProductResponse("Вода", "https://www.uavgusta.net/upload/resize_cache/iblock/d5c/740_740_2/15_faktov_o_roli_vody_v_zhizni_cheloveka.jpg", "Минералочка")
     private val productResponseList = listOf(bread, pie, water)
 
-    override suspend fun getProductItemList(): List<ProductItem> {
+    // TODO: Make this method return domain model instead of presentation model
+    override suspend fun getProductItemList(): List<BaseListItem> {
         return productResponseList.map {
             ProductToListedProductItemMapper().convert(
                 ProductResponseToProductMapper().convert(it)

--- a/app/src/main/java/com/example/hrautomation/domain/model/Product.kt
+++ b/app/src/main/java/com/example/hrautomation/domain/model/Product.kt
@@ -1,7 +1,6 @@
 package com.example.hrautomation.domain.model
 
 import com.example.hrautomation.presentation.model.ListedProductItem
-import com.example.hrautomation.presentation.model.ProductItem
 import com.example.hrautomation.utils.IMapper
 
 data class Product(
@@ -10,7 +9,7 @@ data class Product(
     val name: String
 )
 
-class ProductToListedProductItemMapper : IMapper<Product, ProductItem> {
-    override fun convert(model: Product): ProductItem =
+class ProductToListedProductItemMapper : IMapper<Product, ListedProductItem> {
+    override fun convert(model: Product): ListedProductItem =
         ListedProductItem(model.section, model.img, model.name)
 }

--- a/app/src/main/java/com/example/hrautomation/domain/repository/IProductRepository.kt
+++ b/app/src/main/java/com/example/hrautomation/domain/repository/IProductRepository.kt
@@ -1,7 +1,9 @@
 package com.example.hrautomation.domain.repository
 
-import com.example.hrautomation.presentation.model.ProductItem
+import com.example.hrautomation.presentation.base.delegates.BaseListItem
+
 
 interface IProductRepository {
-    suspend fun getProductItemList(): List<ProductItem>
+
+    suspend fun getProductItemList(): List<BaseListItem>
 }

--- a/app/src/main/java/com/example/hrautomation/presentation/base/delegates/BaseItemAdapterDelegate.kt
+++ b/app/src/main/java/com/example/hrautomation/presentation/base/delegates/BaseItemAdapterDelegate.kt
@@ -1,0 +1,29 @@
+package com.example.hrautomation.presentation.base.delegates
+
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import com.example.hrautomation.R
+import com.hannesdorfmann.adapterdelegates4.AbsListItemAdapterDelegate
+
+abstract class BaseItemAdapterDelegate<I : BaseListItem, VH : RecyclerView.ViewHolder> : AbsListItemAdapterDelegate<I, BaseListItem, VH>() {
+
+    override fun isForViewType(item: BaseListItem, items: MutableList<BaseListItem>, position: Int): Boolean {
+        return isForViewType(item)
+    }
+
+    override fun onBindViewHolder(item: I, holder: VH, payloads: MutableList<Any>) {
+        holder.itemView.setTag(R.id.base_item_tag_key_id, item)
+        onBind(item, holder, payloads)
+    }
+
+    fun getItemForViewHolder(holder: VH): I = getItemFromItemView(holder.itemView)
+
+    fun getItemFromItemView(itemView: View): I {
+        return itemView.getTag(R.id.base_item_tag_key_id) as? I
+            ?: throw IllegalStateException("Item is null or has a wrong type")
+    }
+
+    abstract fun isForViewType(item: BaseListItem): Boolean
+
+    abstract fun onBind(item: I, holder: VH, payloads: List<Any>)
+}

--- a/app/src/main/java/com/example/hrautomation/presentation/base/delegates/BaseListItem.kt
+++ b/app/src/main/java/com/example/hrautomation/presentation/base/delegates/BaseListItem.kt
@@ -1,0 +1,5 @@
+package com.example.hrautomation.presentation.base.delegates
+
+interface BaseListItem {
+    val id: String
+}

--- a/app/src/main/java/com/example/hrautomation/presentation/base/delegates/ClickableViewHolder.kt
+++ b/app/src/main/java/com/example/hrautomation/presentation/base/delegates/ClickableViewHolder.kt
@@ -1,0 +1,16 @@
+package com.example.hrautomation.presentation.base.delegates
+
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+
+abstract class ClickableViewHolder<T : RecyclerView.ViewHolder>(
+    rootView: View,
+    private val onClickListener: OnViewHolderClickListener<T>
+) : RecyclerView.ViewHolder(rootView) {
+
+    init {
+        rootView.setOnClickListener {
+            onClickListener.onViewHolderClick(itemView, holder = this as T)
+        }
+    }
+}

--- a/app/src/main/java/com/example/hrautomation/presentation/base/delegates/OnViewHolderClickListener.kt
+++ b/app/src/main/java/com/example/hrautomation/presentation/base/delegates/OnViewHolderClickListener.kt
@@ -1,0 +1,9 @@
+package com.example.hrautomation.presentation.base.delegates
+
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+
+fun interface OnViewHolderClickListener<VH : RecyclerView.ViewHolder> {
+
+    fun onViewHolderClick(view: View, holder: VH)
+}

--- a/app/src/main/java/com/example/hrautomation/presentation/model/ProductModel.kt
+++ b/app/src/main/java/com/example/hrautomation/presentation/model/ProductModel.kt
@@ -1,13 +1,10 @@
 package com.example.hrautomation.presentation.model
 
-interface ProductItem {
-    val section: String
-    val img: String
-    val name: String
-}
+import com.example.hrautomation.presentation.base.delegates.BaseListItem
 
 data class ListedProductItem(
-    override val section: String,
-    override val img: String,
-    override val name: String
-) : ProductItem
+    val section: String,
+    val img: String,
+    val name: String,
+    override val id: String = name
+) : BaseListItem

--- a/app/src/main/java/com/example/hrautomation/presentation/view/product/ProductAdapter.kt
+++ b/app/src/main/java/com/example/hrautomation/presentation/view/product/ProductAdapter.kt
@@ -1,14 +1,14 @@
 package com.example.hrautomation.presentation.view.product
 
-import com.example.hrautomation.presentation.model.ProductItem
+import com.example.hrautomation.presentation.base.delegates.BaseListItem
 import com.hannesdorfmann.adapterdelegates4.ListDelegationAdapter
 
-class ProductAdapter : ListDelegationAdapter<List<ProductItem>>() {
+class ProductAdapter : ListDelegationAdapter<List<BaseListItem>>() {
     init {
         delegatesManager.addDelegate(ProductListItemAdapterDelegate())
     }
 
-    fun update(data: List<ProductItem>) {
+    fun update(data: List<BaseListItem>) {
         setItems(data)
         notifyDataSetChanged()
     }

--- a/app/src/main/java/com/example/hrautomation/presentation/view/product/ProductFragment.kt
+++ b/app/src/main/java/com/example/hrautomation/presentation/view/product/ProductFragment.kt
@@ -9,7 +9,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import com.example.hrautomation.app.App
 import com.example.hrautomation.databinding.FragmentProductBinding
-import com.example.hrautomation.presentation.model.ProductItem
+import com.example.hrautomation.presentation.base.delegates.BaseListItem
 import com.example.hrautomation.utils.ViewModelFactory
 import javax.inject.Inject
 
@@ -58,7 +58,7 @@ class ProductFragment : Fragment() {
         binding.employeesRecyclerview.adapter = adapter
     }
 
-    private val productObserver = Observer<List<ProductItem>> { newItems ->
+    private val productObserver = Observer<List<BaseListItem>> { newItems ->
         adapter.update(newItems)
     }
 }

--- a/app/src/main/java/com/example/hrautomation/presentation/view/product/ProductFragmentViewModel.kt
+++ b/app/src/main/java/com/example/hrautomation/presentation/view/product/ProductFragmentViewModel.kt
@@ -5,15 +5,15 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.hrautomation.domain.repository.IProductRepository
-import com.example.hrautomation.presentation.model.ProductItem
+import com.example.hrautomation.presentation.base.delegates.BaseListItem
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class ProductFragmentViewModel @Inject constructor(private val repo: IProductRepository) : ViewModel() {
 
-    val data: LiveData<List<ProductItem>>
+    val data: LiveData<List<BaseListItem>>
         get() = _data
-    private val _data = MutableLiveData<List<ProductItem>>(emptyList())
+    private val _data = MutableLiveData<List<BaseListItem>>(emptyList())
 
     init {
         loadData()

--- a/app/src/main/java/com/example/hrautomation/presentation/view/product/ProductListItemAdapterDelegate.kt
+++ b/app/src/main/java/com/example/hrautomation/presentation/view/product/ProductListItemAdapterDelegate.kt
@@ -1,43 +1,55 @@
 package com.example.hrautomation.presentation.view.product
 
+import android.util.Log
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
-import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
+import com.example.hrautomation.R
 import com.example.hrautomation.databinding.ItemProductBinding
+import com.example.hrautomation.presentation.base.delegates.BaseItemAdapterDelegate
+import com.example.hrautomation.presentation.base.delegates.BaseListItem
+import com.example.hrautomation.presentation.base.delegates.ClickableViewHolder
+import com.example.hrautomation.presentation.base.delegates.OnViewHolderClickListener
 import com.example.hrautomation.presentation.model.ListedProductItem
-import com.example.hrautomation.presentation.model.ProductItem
-import com.hannesdorfmann.adapterdelegates4.AbsListItemAdapterDelegate
+import com.example.hrautomation.presentation.view.product.ProductListItemAdapterDelegate.ProductViewHolder
 
-class ProductListItemAdapterDelegate :
-    AbsListItemAdapterDelegate<ListedProductItem, ProductItem, ProductListItemAdapterDelegate.ProductViewHolder>() {
+class ProductListItemAdapterDelegate
+    : BaseItemAdapterDelegate<ListedProductItem, ProductViewHolder>(), OnViewHolderClickListener<ProductViewHolder> {
 
-    override fun isForViewType(
-        item: ProductItem,
-        items: MutableList<ProductItem>,
-        position: Int
-    ): Boolean {
+    override fun isForViewType(item: BaseListItem): Boolean {
         return item is ListedProductItem
     }
 
     override fun onCreateViewHolder(parent: ViewGroup): ProductViewHolder {
         val binding = ItemProductBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return ProductViewHolder(binding)
+        return ProductViewHolder(binding, this)
     }
 
-    override fun onBindViewHolder(
+    override fun onBind(
         product: ListedProductItem,
         vh: ProductViewHolder,
-        payloads: MutableList<Any>
+        payloads: List<Any>
     ) {
         vh.name.text = product.name
-        Glide.with(vh.img.context).load(product.img)
-            .placeholder(com.example.hrautomation.R.drawable.ic_launcher_foreground).into(vh.img)
+
+        Glide.with(vh.img)
+            .load(product.img)
+            .placeholder(R.drawable.ic_launcher_foreground)
+            .into(vh.img)
     }
 
-    class ProductViewHolder(binding: ItemProductBinding) : RecyclerView.ViewHolder(binding.root) {
+    override fun onViewHolderClick(view: View, holder: ProductViewHolder) {
+        val item = getItemForViewHolder(holder)
+        Log.d("ProductListItemAdapterDelegate", "Clicked on view holder ${item.id}")
+    }
+
+    class ProductViewHolder(
+        binding: ItemProductBinding,
+        clickListener: OnViewHolderClickListener<ProductViewHolder>
+    ) : ClickableViewHolder<ProductViewHolder>(binding.root, clickListener) {
         val name: TextView
         val img: ImageView
 

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="base_item_tag_key_id" type="id" />
+</resources>


### PR DESCRIPTION
Импрувменты для делегатов, дабы юзать было удобнее
- Базовый адаптер-делегат с методами для поиска айтема по вьюхолдеру и вью;
- Базовый айтем, чтобы все адаптеры и делегаты подчинялись одинаковым правилам и были взаимозаменяемыми;
- Новый тип вьюхолдера - `ClickableViewHolder` - чтобы удобно обрабатывать клик на всю вьюху сразу;