### PR TITLE
Выделение абстракций для поиска

### DIFF
--- a/app/src/main/java/com/example/hrautomation/domain/model/employees/ListEmployee.kt
+++ b/app/src/main/java/com/example/hrautomation/domain/model/employees/ListEmployee.kt
@@ -1,6 +1,5 @@
 package com.example.hrautomation.domain.model.employees
 
-
 data class ListEmployee(
     val id: Long,
     val username: String,

--- a/app/src/main/java/com/example/hrautomation/presentation/base/search/SearchLoaderDelegate.kt
+++ b/app/src/main/java/com/example/hrautomation/presentation/base/search/SearchLoaderDelegate.kt
@@ -1,0 +1,6 @@
+package com.example.hrautomation.presentation.base.search
+
+interface SearchLoaderDelegate<R> {
+
+    suspend fun loadByRequest(searchRequest: String): R
+}

--- a/app/src/main/java/com/example/hrautomation/presentation/base/search/SearchManager.kt
+++ b/app/src/main/java/com/example/hrautomation/presentation/base/search/SearchManager.kt
@@ -1,0 +1,95 @@
+package com.example.hrautomation.presentation.base.search
+
+import android.text.Editable
+import android.text.TextWatcher
+import android.widget.EditText
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewbinding.ViewBinding
+import com.example.hrautomation.presentation.base.delegates.BaseListItem
+import com.example.hrautomation.utils.tryLaunch
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.lang.ref.WeakReference
+import kotlin.coroutines.CoroutineContext
+
+abstract class SearchManager<I : BaseListItem, VB : ViewBinding, R>(
+    protected val uiDelegate: SearchUiDelegate<I, VB, BaseSearchViewHolder<VB>>,
+    protected val loaderDelegate: SearchLoaderDelegate<R>
+) : CoroutineScope {
+
+    override val coroutineContext: CoroutineContext = Dispatchers.Main + SupervisorJob()
+
+    private val resultAdapter: SearchUiResultAdapter<I, VB> = SearchUiResultAdapter(uiDelegate)
+
+    private var searchView: WeakReference<EditText>? = null
+    private var resultContainer: WeakReference<RecyclerView>? = null
+
+    private var isAttached: Boolean = false
+
+    open fun attach(newSearchView: EditText, newResultContainer: RecyclerView) {
+        searchView?.get()?.removeTextChangedListener(textWatcher)
+        resultContainer?.get()?.adapter = null
+
+        searchView = WeakReference(newSearchView)
+        resultContainer = WeakReference(newResultContainer)
+
+        newResultContainer.adapter = resultAdapter
+        newResultContainer.layoutManager = LinearLayoutManager(newResultContainer.context)
+        newSearchView.addTextChangedListener(textWatcher)
+
+        isAttached = true
+        onAttached()
+    }
+
+    open fun detach() {
+        searchView?.get()?.removeTextChangedListener(textWatcher)
+        resultContainer?.get()?.adapter = null
+
+        searchView = null
+        resultContainer = null
+
+        isAttached = false
+        onDetached()
+    }
+
+    protected fun processSearch(request: String) {
+        if (isAttached) {
+            tryLaunch(
+                doOnLaunch = {
+                    onLoadingStarted()
+                    val items = withContext(Dispatchers.IO) {
+                        val data = loaderDelegate.loadByRequest(request)
+                        convertToItems(data)
+                    }
+                    resultAdapter.setItems(items)
+                    onLoadingFinished()
+                },
+                doOnError = { error -> Timber.e(error) }
+            )
+
+        }
+    }
+
+    abstract fun convertToItems(data: R): List<I>
+
+    open fun onAttached() = Unit
+    open fun onDetached() = Unit
+    open fun onLoadingStarted() = Unit
+    open fun onLoadingFinished() = Unit
+
+    protected open val textWatcher = object : TextWatcher {
+
+        override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) = Unit
+
+        override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) = Unit
+
+        override fun afterTextChanged(editableText: Editable?) {
+            val request = editableText.toString()
+            processSearch(request)
+        }
+    }
+}

--- a/app/src/main/java/com/example/hrautomation/presentation/base/search/SearchUiDelegate.kt
+++ b/app/src/main/java/com/example/hrautomation/presentation/base/search/SearchUiDelegate.kt
@@ -1,0 +1,14 @@
+package com.example.hrautomation.presentation.base.search
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewbinding.ViewBinding
+import com.example.hrautomation.presentation.base.delegates.BaseListItem
+
+interface SearchUiDelegate<Item : BaseListItem, VB : ViewBinding, VH : RecyclerView.ViewHolder> {
+
+    fun getLayout(parent: ViewGroup, inflater: LayoutInflater): VB
+
+    fun bind(item: Item, holder: VH)
+}

--- a/app/src/main/java/com/example/hrautomation/presentation/base/search/SearchUiResultAdapter.kt
+++ b/app/src/main/java/com/example/hrautomation/presentation/base/search/SearchUiResultAdapter.kt
@@ -1,0 +1,36 @@
+package com.example.hrautomation.presentation.base.search
+
+import android.annotation.SuppressLint
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewbinding.ViewBinding
+import com.example.hrautomation.presentation.base.delegates.BaseListItem
+
+class SearchUiResultAdapter<Item : BaseListItem, VB : ViewBinding>(
+    private val uiDelegate: SearchUiDelegate<Item, VB, BaseSearchViewHolder<VB>>
+) : RecyclerView.Adapter<BaseSearchViewHolder<VB>>() {
+
+    private var items: List<Item> = emptyList()
+
+    @SuppressLint("NotifyDataSetChanged")
+    fun setItems(newItems: List<Item>) {
+        items = newItems
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BaseSearchViewHolder<VB> {
+        val viewBinding = uiDelegate.getLayout(parent, LayoutInflater.from(parent.context))
+        return BaseSearchViewHolder(viewBinding)
+    }
+
+    override fun onBindViewHolder(holder: BaseSearchViewHolder<VB>, position: Int) {
+        val item = items[position]
+        uiDelegate.bind(item, holder)
+    }
+
+    override fun getItemCount(): Int = items.size
+
+}
+
+class BaseSearchViewHolder<VB : ViewBinding>(val viewBinding: VB) : RecyclerView.ViewHolder(viewBinding.root)

--- a/app/src/main/java/com/example/hrautomation/presentation/view/colleagues/search/ColleaguesSearchLoaderDelegate.kt
+++ b/app/src/main/java/com/example/hrautomation/presentation/view/colleagues/search/ColleaguesSearchLoaderDelegate.kt
@@ -1,0 +1,36 @@
+package com.example.hrautomation.presentation.view.colleagues.search
+
+import com.example.hrautomation.domain.model.employees.ColleaguesSortBy
+import com.example.hrautomation.domain.model.employees.ListEmployee
+import com.example.hrautomation.domain.repository.EmployeesRepository
+import com.example.hrautomation.presentation.base.search.SearchLoaderDelegate
+import com.example.hrautomation.utils.isNullOrEmptyOrBlank
+import javax.inject.Inject
+
+class ColleaguesSearchLoaderDelegate @Inject constructor(
+    private val employeesRepository: EmployeesRepository
+) : SearchLoaderDelegate<List<ListEmployee>> {
+
+    private var persistentResult: List<ListEmployee>? = null
+
+    override suspend fun loadByRequest(searchRequest: String): List<ListEmployee> {
+        val workers = getWorkers()
+        return if (!searchRequest.isNullOrEmptyOrBlank()) {
+            workers.filter { it.username.contains(searchRequest) }
+        } else {
+            workers
+        }
+    }
+
+    private suspend fun getWorkers(): List<ListEmployee> {
+        if (persistentResult == null) {
+            persistentResult = employeesRepository.getEmployeeList(PAGE_NUMBER, PAGE_SIZE, ColleaguesSortBy.NAME)
+        }
+        return persistentResult!!
+    }
+
+    private companion object {
+        const val PAGE_SIZE = 100
+        const val PAGE_NUMBER = 0
+    }
+}

--- a/app/src/main/java/com/example/hrautomation/presentation/view/colleagues/search/ColleaguesSearchManager.kt
+++ b/app/src/main/java/com/example/hrautomation/presentation/view/colleagues/search/ColleaguesSearchManager.kt
@@ -1,0 +1,52 @@
+package com.example.hrautomation.presentation.view.colleagues.search
+
+import com.example.hrautomation.databinding.ItemEmployeeBinding
+import com.example.hrautomation.domain.model.employees.ListEmployee
+import com.example.hrautomation.presentation.base.search.SearchManager
+import com.example.hrautomation.presentation.model.colleagues.EmployeeToColleagueItemMapper
+import com.example.hrautomation.presentation.model.colleagues.ListedColleagueItem
+import javax.inject.Inject
+
+class ColleaguesSearchManager @Inject constructor(
+    private val colleaguesLoaderDelegate: ColleaguesSearchLoaderDelegate,
+    private val employeeToColleagueItemMapper: EmployeeToColleagueItemMapper,
+) : SearchManager<ListedColleagueItem, ItemEmployeeBinding, List<ListEmployee>>(
+    ColleaguesSearchUiDelegate(),
+    colleaguesLoaderDelegate
+) {
+
+    private var onLoadingStartedListener: (() -> Unit)? = null
+    private var onLoadingFinishedListener: (() -> Unit)? = null
+
+    fun applyDefaultSearchResult() {
+        processSearch(EMPTY_REQUEST)
+    }
+
+    override fun convertToItems(data: List<ListEmployee>): List<ListedColleagueItem> {
+        return data.map { employeeToColleagueItemMapper.convert(it) }
+    }
+
+    override fun onLoadingStarted() {
+        onLoadingStartedListener?.invoke()
+    }
+
+    override fun onLoadingFinished() {
+        onLoadingFinishedListener?.invoke()
+    }
+
+    fun setOnResultClickListener(listener: ((Long) -> Unit)?) {
+        (uiDelegate as ColleaguesSearchUiDelegate).setOnResultClickListener(listener)
+    }
+
+    fun setOnLoadingStartedListener(listener: (() -> Unit)?) {
+        this.onLoadingStartedListener = listener
+    }
+
+    fun setOnLoadingFinishedListener(listener: (() -> Unit)?) {
+        this.onLoadingFinishedListener = listener
+    }
+
+    private companion object {
+        const val EMPTY_REQUEST = ""
+    }
+}

--- a/app/src/main/java/com/example/hrautomation/presentation/view/colleagues/search/ColleaguesSearchUiDelegate.kt
+++ b/app/src/main/java/com/example/hrautomation/presentation/view/colleagues/search/ColleaguesSearchUiDelegate.kt
@@ -1,0 +1,41 @@
+package com.example.hrautomation.presentation.view.colleagues.search
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import com.bumptech.glide.Glide
+import com.example.hrautomation.R
+import com.example.hrautomation.databinding.ItemEmployeeBinding
+import com.example.hrautomation.presentation.base.search.BaseSearchViewHolder
+import com.example.hrautomation.presentation.base.search.SearchUiDelegate
+import com.example.hrautomation.presentation.model.colleagues.ListedColleagueItem
+
+class ColleaguesSearchUiDelegate :
+    SearchUiDelegate<ListedColleagueItem, ItemEmployeeBinding, BaseSearchViewHolder<ItemEmployeeBinding>> {
+
+    private var onResultClickListener: ((Long) -> Unit)? = null
+
+    override fun getLayout(parent: ViewGroup, inflater: LayoutInflater): ItemEmployeeBinding {
+        return ItemEmployeeBinding.inflate(inflater, parent, false)
+    }
+
+    override fun bind(item: ListedColleagueItem, holder: BaseSearchViewHolder<ItemEmployeeBinding>) {
+        with(holder.viewBinding) {
+            employeeName.text = item.name
+            employeePost.text = item.post
+
+            Glide.with(employeeImage)
+                .load(item.pictureUrl)
+                .centerCrop()
+                .placeholder(R.drawable.ic_confused)
+                .into(employeeImage)
+
+            root.setOnClickListener {
+                onResultClickListener?.invoke(item.id)
+            }
+        }
+    }
+
+    fun setOnResultClickListener(listener: ((Long) -> Unit)?) {
+        this.onResultClickListener = listener
+    }
+}

--- a/app/src/main/java/com/example/hrautomation/utils/StringUtilsExt.kt
+++ b/app/src/main/java/com/example/hrautomation/utils/StringUtilsExt.kt
@@ -1,0 +1,5 @@
+package com.example.hrautomation.utils
+
+fun String?.isNullOrEmptyOrBlank(): Boolean {
+    return this == null || this.isEmpty() || this.isBlank()
+}


### PR DESCRIPTION
Добавил абстрактные классы для интеграции поиска в фичи. 
`SearchManager` - корневая абстракция, управляющая загрузкой данных через делегат загрузки и их отображением через делегат отображения.
`SearchLoaderDelegate` - делегат для загрузки данных. Имеет один-единственный метод: загрузка данных по введенному реквесту поиска.
`SearchUiDelegate` - делегат для отображения данных. Берет на себя ответственность за бинд данных ко вью (аналог adapter-delegate, но чуть короче под стандартный кейс отображения данных)
`SearchUiResultAdapter` - обычный базовый адаптер для ресайклера результатов поиска. Хранит айтемы (отфильтрованный результат) и использует `SearchUiDelegate`, чтобы биндить айтемы ко вью.

Менеджер имплементирован на экран поиска, но нужна доработка с сохранением стейта, стартовым запуском и совместимостью с контент-свитчером.


